### PR TITLE
added Installed-Size control field support

### DIFF
--- a/deb/control.go
+++ b/deb/control.go
@@ -36,20 +36,28 @@ func NewControlDefault(name, maintainerName, maintainerEmail, shortDescription, 
 	sourcePackage := (*ctrl)[0]
 	sourcePackage.Set(SourceFName, name)
 	sourcePackage.Set(MaintainerFName, fmt.Sprintf("%s <%s>", maintainerName, maintainerEmail))
-	sourcePackage.Set(DescriptionFName, fmt.Sprintf("%s\n%s", shortDescription, longDescription))
+	description := shortDescription
+	if longDescription != "" {
+		description = fmt.Sprintf("%s\n %s", shortDescription, longDescription)
+	}
+	sourcePackage.Set(DescriptionFName, description)
 	//BuildDepends is empty...
 	//add binary package
 	binPackage := NewPackage()
 	*ctrl = append(*ctrl, binPackage)
 	binPackage.Set(PackageFName, name)
-	binPackage.Set(DescriptionFName, fmt.Sprintf("%s\n%s", shortDescription, longDescription))
+	binPackage.Set(DescriptionFName, description)
 	//depends is empty
 	if addDevPackage {
 		devPackage := NewPackage()
 		*ctrl = append(*ctrl, devPackage)
 		devPackage.Set(PackageFName, name+"-dev")
 		devPackage.Set(ArchitectureFName, "all")
-		devPackage.Set(DescriptionFName, fmt.Sprintf("%s - development package\n%s", shortDescription, longDescription))
+		description = fmt.Sprintf("%s - development package", shortDescription)
+		if longDescription != "" {
+			description = fmt.Sprintf("%s - development package\n %s", shortDescription, longDescription)
+		}
+		devPackage.Set(DescriptionFName, description)
 	}
 	SetDefaults(ctrl)
 	return ctrl

--- a/debgen/constants.go
+++ b/debgen/constants.go
@@ -78,6 +78,8 @@ Version: {{.Package.Get "Version"}}
 Architecture: {{.Deb.Architecture}}
 {{if .Package.Get "Depends"}}Depends: {{.Package.Get "Depends"}}
 {{end}}Description: {{.Package.Get "Description"}}
+{{if .Package.Get "Installed-Size"}}Installed-Size: {{.Package.Get "Installed-Size"}}
+{{end}}
 `
 
 	// The debian control file (source debs) defines general package metadata (but not version information)


### PR DESCRIPTION
I conditionally add the `longDescription` because if it is empty and a newline is added it results in a control file such as 
```
Description: short descr here

Installed-Size: 100
```
where the newline causes issues. The parser (at least in ubuntu) stops at the first newline. I can move around the order of fields in `debgen/constants.go` if you prefer I remove the conditionals for the `description`. Also, you'll notice a space added before the long description (if it is present). The space is required per the description control field [docs](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Description).

Besides that, this code assumes you have at least one source file and the first source file is the main binary (the first file found in `dgen.DataFiles`). Otherwise it just skips adding the `Installed-Size` control field.

I'm still becoming familiar with the debber codebase, so let me know if you would like me to change anything!